### PR TITLE
Test on Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev
 cache:
   pip: true
   directories:


### PR DESCRIPTION
Python 3.9.0 release candidate 2 is out, with the final 3.9.0 due on 2020-10-05.

* https://www.python.org/dev/peps/pep-0596/#release-schedule

It's recommended to test third-party libraries already, to make test both the library and Python 3.9 itself.