### PR TITLE
Added supported google-cloud-firestore versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -581,7 +581,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<4.0"
-content-hash = "e71337ac353ea13e998e3582d820bd35d574c4dc8086bcc2c20f16b4378f9d90"
+content-hash = "1c06a635b04c2e5c901e7cbe3dbb8e1c30fee8022a5b4bb66704888a7c293064"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 python = ">=3.6.1,<4.0"
 pydantic = "^1.8.2"
 grpcio = "^1.36.1"
-google-cloud-firestore = "^2.1.0"
+google-cloud-firestore = "^2.0.1"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.5.2"


### PR DESCRIPTION
Because Poetry does not yet allow ignoring version dependency numbers I need Firedantic to not depend on a broken version of google-cloud-firestore: https://github.com/python-poetry/poetry/issues/697

For most people this will still install the latest version, but I can pin the version to 2.0.2 with this change until Google fixes the big with the emulator support https://github.com/googleapis/python-firestore/issues/359