### PR TITLE
Support for custom document IDs

### DIFF
--- a/firedantic/__init__.py
+++ b/firedantic/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from firedantic._async.helpers import truncate_collection as async_truncate_collection
-from firedantic._async.model import AsyncModel
+from firedantic._async.model import AsyncBareModel, AsyncModel
 from firedantic._sync.helpers import truncate_collection
-from firedantic._sync.model import Model
+from firedantic._sync.model import BareModel, Model
 from firedantic.configurations import CONFIGURATIONS, configure
 from firedantic.exceptions import *

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -3,7 +3,11 @@ from logging import getLogger
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 import pydantic
-from google.cloud.firestore_v1 import AsyncCollectionReference, AsyncDocumentReference
+from google.cloud.firestore_v1 import (
+    AsyncCollectionReference,
+    AsyncDocumentReference,
+    DocumentSnapshot,
+)
 from google.cloud.firestore_v1.async_query import AsyncQuery
 
 import firedantic.operators as op
@@ -112,10 +116,11 @@ class AsyncModel(pydantic.BaseModel, ABC):
                     raise ValueError(
                         f"Unsupported filter type: {f_type}. Supported types are: {', '.join(FIND_TYPES)}"
                     )
-                query = query.where(field, f_type, value[f_type])  # type: ignore
+                query: AsyncQuery = query.where(field, f_type, value[f_type])  # type: ignore
             return query
         else:
-            return query.where(field, "==", value)  # type: ignore
+            query: AsyncQuery = query.where(field, "==", value)  # type: ignore
+            return query
 
     @classmethod
     async def find_one(
@@ -141,8 +146,8 @@ class AsyncModel(pydantic.BaseModel, ABC):
         :return: The model.
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
-        document = await cls._get_col_ref().document(id_).get()  # type: ignore
-        data = document.to_dict()  # type: ignore
+        document: DocumentSnapshot = await cls._get_col_ref().document(id_).get()  # type: ignore
+        data = document.to_dict()
         if data is None:
             raise ModelNotFoundError(f"No '{cls.__name__}' found with id '{id_}'")
         data["id"] = id_

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Type, TypeVar, Union
 
 import pydantic
 from google.cloud.firestore_v1 import AsyncCollectionReference, AsyncDocumentReference
-from google.cloud.firestore_v1.base_query import BaseQuery
+from google.cloud.firestore_v1.async_query import AsyncQuery
 
 import firedantic.operators as op
 from firedantic import async_truncate_collection
@@ -77,7 +77,7 @@ class AsyncModel(pydantic.BaseModel, ABC):
 
         coll = cls._get_col_ref()
 
-        query: Union[BaseQuery, AsyncCollectionReference] = coll
+        query: Union[AsyncQuery, AsyncCollectionReference] = coll
 
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
@@ -104,8 +104,8 @@ class AsyncModel(pydantic.BaseModel, ABC):
 
     @classmethod
     def _add_filter(
-        cls, query: Union[BaseQuery, AsyncCollectionReference], field: str, value: Any
-    ) -> Union[BaseQuery, AsyncCollectionReference]:
+        cls, query: Union[AsyncQuery, AsyncCollectionReference], field: str, value: Any
+    ) -> Union[AsyncQuery, AsyncCollectionReference]:
         if type(value) is dict:
             for f_type in value:
                 if f_type not in FIND_TYPES:

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -15,7 +15,7 @@ from firedantic import async_truncate_collection
 from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
 
-TAsyncModel = TypeVar("TAsyncModel", bound="AsyncBareModel")
+TAsyncConcreteModel = TypeVar("TAsyncConcreteModel", bound="AsyncBareModel")
 logger = getLogger("firedantic")
 
 # https://firebase.google.com/docs/firestore/query-data/queries#query_operators
@@ -64,8 +64,8 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     async def find(
-        cls: Type[TAsyncModel], filter_: Optional[dict] = None
-    ) -> List[TAsyncModel]:
+        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
+    ) -> List[TAsyncConcreteModel]:
         """Returns a list of models from the database based on a filter.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -84,7 +84,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
 
-        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncModel:
+        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncConcreteModel:
             if cls.__document_id__ in data:
                 logger.warning(
                     "%s document ID %s contains conflicting %s in data with value %s",
@@ -122,8 +122,8 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     async def find_one(
-        cls: Type[TAsyncModel], filter_: Optional[dict] = None
-    ) -> TAsyncModel:
+        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
+    ) -> TAsyncConcreteModel:
         """Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.
@@ -137,7 +137,9 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
             raise ModelNotFoundError(f"No '{cls.__name__}' found")
 
     @classmethod
-    async def get_by_id(cls: Type[TAsyncModel], id_: str) -> TAsyncModel:
+    async def get_by_id(
+        cls: Type[TAsyncConcreteModel], id_: str
+    ) -> TAsyncConcreteModel:
         """Returns a model based on the ID.
 
         :param id_: The id of the entry.

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -33,16 +33,14 @@ FIND_TYPES = {
 }
 
 
-class AsyncModel(pydantic.BaseModel, ABC):
+class AsyncBareModel(pydantic.BaseModel, ABC):
     """Base model class.
 
     Implements basic functionality for Pydantic models, such as save, delete, find etc.
     """
 
     __collection__: Optional[str] = None
-    __document_id__: str = "id"
-
-    id: Optional[str] = None
+    __document_id__: str
 
     async def save(self) -> None:
         """Saves this model in the database."""
@@ -178,3 +176,8 @@ class AsyncModel(pydantic.BaseModel, ABC):
     def _get_doc_ref(self) -> AsyncDocumentReference:
         """Returns the document reference."""
         return self._get_col_ref().document(self.get_document_id())  # type: ignore
+
+
+class AsyncModel(AsyncBareModel):
+    __document_id__: str = "id"
+    id: Optional[str] = None

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from logging import getLogger
-from typing import Any, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 import pydantic
 from google.cloud.firestore_v1 import AsyncCollectionReference, AsyncDocumentReference
@@ -82,7 +82,7 @@ class AsyncModel(pydantic.BaseModel, ABC):
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
 
-        def _cls(doc_id, data) -> TAsyncModel:
+        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncModel:
             if cls.__document_id__ in data:
                 logger.warning(
                     "%s document ID %s contains conflicting %s in data with value %s",
@@ -112,10 +112,10 @@ class AsyncModel(pydantic.BaseModel, ABC):
                     raise ValueError(
                         f"Unsupported filter type: {f_type}. Supported types are: {', '.join(FIND_TYPES)}"
                     )
-                query = query.where(field, f_type, value[f_type])
+                query = query.where(field, f_type, value[f_type])  # type: ignore
             return query
         else:
-            return query.where(field, "==", value)
+            return query.where(field, "==", value)  # type: ignore
 
     @classmethod
     async def find_one(
@@ -142,7 +142,7 @@ class AsyncModel(pydantic.BaseModel, ABC):
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
         document = await cls._get_col_ref().document(id_).get()  # type: ignore
-        data = document.to_dict()
+        data = document.to_dict()  # type: ignore
         if data is None:
             raise ModelNotFoundError(f"No '{cls.__name__}' found with id '{id_}'")
         data["id"] = id_

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -185,5 +185,5 @@ class AsyncModel(AsyncBareModel):
     id: Optional[str] = None
 
     @classmethod
-    async def get_by_id(cls: Type[TAsyncBareModel], doc_id: str) -> TAsyncBareModel:
-        return await cls.get_by_doc_id(doc_id)
+    async def get_by_id(cls: Type[TAsyncBareModel], id_: str) -> TAsyncBareModel:
+        return await cls.get_by_doc_id(id_)

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -15,7 +15,7 @@ from firedantic import async_truncate_collection
 from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
 
-TAsyncConcreteModel = TypeVar("TAsyncConcreteModel", bound="AsyncBareModel")
+TAsyncBareModel = TypeVar("TAsyncBareModel", bound="AsyncBareModel")
 logger = getLogger("firedantic")
 
 # https://firebase.google.com/docs/firestore/query-data/queries#query_operators
@@ -64,8 +64,8 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     async def find(
-        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
-    ) -> List[TAsyncConcreteModel]:
+        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
+    ) -> List[TAsyncBareModel]:
         """Returns a list of models from the database based on a filter.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -84,7 +84,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
 
-        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncConcreteModel:
+        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncBareModel:
             if cls.__document_id__ in data:
                 logger.warning(
                     "%s document ID %s contains conflicting %s in data with value %s",
@@ -122,8 +122,8 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     async def find_one(
-        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
-    ) -> TAsyncConcreteModel:
+        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
+    ) -> TAsyncBareModel:
         """Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.
@@ -137,9 +137,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
             raise ModelNotFoundError(f"No '{cls.__name__}' found")
 
     @classmethod
-    async def get_by_id(
-        cls: Type[TAsyncConcreteModel], id_: str
-    ) -> TAsyncConcreteModel:
+    async def get_by_id(cls: Type[TAsyncBareModel], id_: str) -> TAsyncBareModel:
         """Returns a model based on the ID.
 
         :param id_: The id of the entry.

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -15,7 +15,7 @@ from firedantic import async_truncate_collection
 from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
 
-TAsyncModel = TypeVar("TAsyncModel", bound="AsyncModel")
+TAsyncModel = TypeVar("TAsyncModel", bound="AsyncBareModel")
 logger = getLogger("firedantic")
 
 # https://firebase.google.com/docs/firestore/query-data/queries#query_operators

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -3,7 +3,11 @@ from logging import getLogger
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 import pydantic
-from google.cloud.firestore_v1 import CollectionReference, DocumentReference
+from google.cloud.firestore_v1 import (
+    CollectionReference,
+    DocumentReference,
+    DocumentSnapshot,
+)
 from google.cloud.firestore_v1.base_query import BaseQuery
 
 import firedantic.operators as op
@@ -110,10 +114,11 @@ class Model(pydantic.BaseModel, ABC):
                     raise ValueError(
                         f"Unsupported filter type: {f_type}. Supported types are: {', '.join(FIND_TYPES)}"
                     )
-                query = query.where(field, f_type, value[f_type])  # type: ignore
+                query: BaseQuery = query.where(field, f_type, value[f_type])  # type: ignore
             return query
         else:
-            return query.where(field, "==", value)  # type: ignore
+            query: BaseQuery = query.where(field, "==", value)  # type: ignore
+            return query
 
     @classmethod
     def find_one(cls: Type[TModel], filter_: Optional[dict] = None) -> TModel:
@@ -137,8 +142,8 @@ class Model(pydantic.BaseModel, ABC):
         :return: The model.
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
-        document = cls._get_col_ref().document(id_).get()  # type: ignore
-        data = document.to_dict()  # type: ignore
+        document: DocumentSnapshot = cls._get_col_ref().document(id_).get()  # type: ignore
+        data = document.to_dict()
         if data is None:
             raise ModelNotFoundError(f"No '{cls.__name__}' found with id '{id_}'")
         data["id"] = id_

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -181,5 +181,5 @@ class Model(BareModel):
     id: Optional[str] = None
 
     @classmethod
-    def get_by_id(cls: Type[TBareModel], doc_id: str) -> TBareModel:
-        return cls.get_by_doc_id(doc_id)
+    def get_by_id(cls: Type[TBareModel], id_: str) -> TBareModel:
+        return cls.get_by_doc_id(id_)

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -15,7 +15,7 @@ from firedantic import truncate_collection
 from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
 
-TModel = TypeVar("TModel", bound="BareModel")
+TAsyncConcreteModel = TypeVar("TAsyncConcreteModel", bound="BareModel")
 logger = getLogger("firedantic")
 
 # https://firebase.google.com/docs/firestore/query-data/queries#query_operators
@@ -63,7 +63,9 @@ class BareModel(pydantic.BaseModel, ABC):
         return getattr(self, self.__document_id__, None)
 
     @classmethod
-    def find(cls: Type[TModel], filter_: Optional[dict] = None) -> List[TModel]:
+    def find(
+        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
+    ) -> List[TAsyncConcreteModel]:
         """Returns a list of models from the database based on a filter.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -82,7 +84,7 @@ class BareModel(pydantic.BaseModel, ABC):
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
 
-        def _cls(doc_id: str, data: Dict[str, Any]) -> TModel:
+        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncConcreteModel:
             if cls.__document_id__ in data:
                 logger.warning(
                     "%s document ID %s contains conflicting %s in data with value %s",
@@ -119,7 +121,9 @@ class BareModel(pydantic.BaseModel, ABC):
             return query
 
     @classmethod
-    def find_one(cls: Type[TModel], filter_: Optional[dict] = None) -> TModel:
+    def find_one(
+        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
+    ) -> TAsyncConcreteModel:
         """Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.
@@ -133,7 +137,7 @@ class BareModel(pydantic.BaseModel, ABC):
             raise ModelNotFoundError(f"No '{cls.__name__}' found")
 
     @classmethod
-    def get_by_id(cls: Type[TModel], id_: str) -> TModel:
+    def get_by_id(cls: Type[TAsyncConcreteModel], id_: str) -> TAsyncConcreteModel:
         """Returns a model based on the ID.
 
         :param id_: The id of the entry.

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -33,16 +33,14 @@ FIND_TYPES = {
 }
 
 
-class Model(pydantic.BaseModel, ABC):
+class BareModel(pydantic.BaseModel, ABC):
     """Base model class.
 
     Implements basic functionality for Pydantic models, such as save, delete, find etc.
     """
 
     __collection__: Optional[str] = None
-    __document_id__: str = "id"
-
-    id: Optional[str] = None
+    __document_id__: str
 
     def save(self) -> None:
         """Saves this model in the database."""
@@ -174,3 +172,8 @@ class Model(pydantic.BaseModel, ABC):
     def _get_doc_ref(self) -> DocumentReference:
         """Returns the document reference."""
         return self._get_col_ref().document(self.get_document_id())  # type: ignore
+
+
+class Model(BareModel):
+    __document_id__: str = "id"
+    id: Optional[str] = None

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from logging import getLogger
-from typing import Any, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 import pydantic
 from google.cloud.firestore_v1 import CollectionReference, DocumentReference
@@ -80,7 +80,7 @@ class Model(pydantic.BaseModel, ABC):
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
 
-        def _cls(doc_id, data) -> TModel:
+        def _cls(doc_id: str, data: Dict[str, Any]) -> TModel:
             if cls.__document_id__ in data:
                 logger.warning(
                     "%s document ID %s contains conflicting %s in data with value %s",
@@ -110,10 +110,10 @@ class Model(pydantic.BaseModel, ABC):
                     raise ValueError(
                         f"Unsupported filter type: {f_type}. Supported types are: {', '.join(FIND_TYPES)}"
                     )
-                query = query.where(field, f_type, value[f_type])
+                query = query.where(field, f_type, value[f_type])  # type: ignore
             return query
         else:
-            return query.where(field, "==", value)
+            return query.where(field, "==", value)  # type: ignore
 
     @classmethod
     def find_one(cls: Type[TModel], filter_: Optional[dict] = None) -> TModel:
@@ -138,7 +138,7 @@ class Model(pydantic.BaseModel, ABC):
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
         document = cls._get_col_ref().document(id_).get()  # type: ignore
-        data = document.to_dict()
+        data = document.to_dict()  # type: ignore
         if data is None:
             raise ModelNotFoundError(f"No '{cls.__name__}' found with id '{id_}'")
         data["id"] = id_

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -15,7 +15,7 @@ from firedantic import truncate_collection
 from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
 
-TAsyncConcreteModel = TypeVar("TAsyncConcreteModel", bound="BareModel")
+TAsyncBareModel = TypeVar("TAsyncBareModel", bound="BareModel")
 logger = getLogger("firedantic")
 
 # https://firebase.google.com/docs/firestore/query-data/queries#query_operators
@@ -64,8 +64,8 @@ class BareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     def find(
-        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
-    ) -> List[TAsyncConcreteModel]:
+        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
+    ) -> List[TAsyncBareModel]:
         """Returns a list of models from the database based on a filter.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -84,7 +84,7 @@ class BareModel(pydantic.BaseModel, ABC):
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
 
-        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncConcreteModel:
+        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncBareModel:
             if cls.__document_id__ in data:
                 logger.warning(
                     "%s document ID %s contains conflicting %s in data with value %s",
@@ -122,8 +122,8 @@ class BareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     def find_one(
-        cls: Type[TAsyncConcreteModel], filter_: Optional[dict] = None
-    ) -> TAsyncConcreteModel:
+        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
+    ) -> TAsyncBareModel:
         """Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.
@@ -137,7 +137,7 @@ class BareModel(pydantic.BaseModel, ABC):
             raise ModelNotFoundError(f"No '{cls.__name__}' found")
 
     @classmethod
-    def get_by_id(cls: Type[TAsyncConcreteModel], id_: str) -> TAsyncConcreteModel:
+    def get_by_id(cls: Type[TAsyncBareModel], id_: str) -> TAsyncBareModel:
         """Returns a model based on the ID.
 
         :param id_: The id of the entry.

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -133,18 +133,20 @@ class BareModel(pydantic.BaseModel, ABC):
             raise ModelNotFoundError(f"No '{cls.__name__}' found")
 
     @classmethod
-    def get_by_id(cls: Type[TBareModel], id_: str) -> TBareModel:
-        """Returns a model based on the ID.
+    def get_by_doc_id(cls: Type[TBareModel], doc_id: str) -> TBareModel:
+        """Returns a model based on the document ID.
 
-        :param id_: The id of the entry.
+        :param doc_id: The document ID of the entry.
         :return: The model.
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
-        document: DocumentSnapshot = cls._get_col_ref().document(id_).get()  # type: ignore
+        document: DocumentSnapshot = cls._get_col_ref().document(doc_id).get()  # type: ignore
         data = document.to_dict()
         if data is None:
-            raise ModelNotFoundError(f"No '{cls.__name__}' found with id '{id_}'")
-        data["id"] = id_
+            raise ModelNotFoundError(
+                f"No '{cls.__name__}' found with {cls.__document_id__} '{doc_id}'"
+            )
+        data[cls.__document_id__] = doc_id
         return cls(**data)
 
     @classmethod
@@ -177,3 +179,7 @@ class BareModel(pydantic.BaseModel, ABC):
 class Model(BareModel):
     __document_id__: str = "id"
     id: Optional[str] = None
+
+    @classmethod
+    def get_by_id(cls: Type[TBareModel], doc_id: str) -> TBareModel:
+        return cls.get_by_doc_id(doc_id)

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -15,7 +15,7 @@ from firedantic import truncate_collection
 from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
 
-TModel = TypeVar("TModel", bound="Model")
+TModel = TypeVar("TModel", bound="BareModel")
 logger = getLogger("firedantic")
 
 # https://firebase.google.com/docs/firestore/query-data/queries#query_operators

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -15,7 +15,7 @@ from firedantic import truncate_collection
 from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
 
-TAsyncBareModel = TypeVar("TAsyncBareModel", bound="BareModel")
+TBareModel = TypeVar("TBareModel", bound="BareModel")
 logger = getLogger("firedantic")
 
 # https://firebase.google.com/docs/firestore/query-data/queries#query_operators
@@ -63,9 +63,7 @@ class BareModel(pydantic.BaseModel, ABC):
         return getattr(self, self.__document_id__, None)
 
     @classmethod
-    def find(
-        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
-    ) -> List[TAsyncBareModel]:
+    def find(cls: Type[TBareModel], filter_: Optional[dict] = None) -> List[TBareModel]:
         """Returns a list of models from the database based on a filter.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -84,7 +82,7 @@ class BareModel(pydantic.BaseModel, ABC):
         for key, value in filter_.items():
             query = cls._add_filter(query, key, value)
 
-        def _cls(doc_id: str, data: Dict[str, Any]) -> TAsyncBareModel:
+        def _cls(doc_id: str, data: Dict[str, Any]) -> TBareModel:
             if cls.__document_id__ in data:
                 logger.warning(
                     "%s document ID %s contains conflicting %s in data with value %s",
@@ -121,9 +119,7 @@ class BareModel(pydantic.BaseModel, ABC):
             return query
 
     @classmethod
-    def find_one(
-        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
-    ) -> TAsyncBareModel:
+    def find_one(cls: Type[TBareModel], filter_: Optional[dict] = None) -> TBareModel:
         """Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.
@@ -137,7 +133,7 @@ class BareModel(pydantic.BaseModel, ABC):
             raise ModelNotFoundError(f"No '{cls.__name__}' found")
 
     @classmethod
-    def get_by_id(cls: Type[TAsyncBareModel], id_: str) -> TAsyncBareModel:
+    def get_by_id(cls: Type[TBareModel], id_: str) -> TBareModel:
         """Returns a model based on the ID.
 
         :param id_: The id of the entry.

--- a/firedantic/tests/tests_async/conftest.py
+++ b/firedantic/tests/tests_async/conftest.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List
+from typing import List, Optional
 from unittest.mock import Mock
 
 import google.auth.credentials
@@ -9,6 +9,21 @@ from pydantic import BaseModel
 
 from firedantic import AsyncModel
 from firedantic.configurations import configure
+
+
+class CustomIDModel(AsyncModel):
+    __collection__ = "custom"
+    __document_id__ = "foo"
+
+    foo: Optional[str]
+    bar: str
+
+
+class CustomIDConflictModel(AsyncModel):
+    __collection__ = "custom"
+
+    foo: str
+    bar: str
 
 
 class Owner(BaseModel):

--- a/firedantic/tests/tests_async/conftest.py
+++ b/firedantic/tests/tests_async/conftest.py
@@ -7,11 +7,11 @@ import pytest
 from google.cloud.firestore_v1 import AsyncClient
 from pydantic import BaseModel
 
-from firedantic import AsyncModel
+from firedantic import AsyncBareModel, AsyncModel
 from firedantic.configurations import configure
 
 
-class CustomIDModel(AsyncModel):
+class CustomIDModel(AsyncBareModel):
     __collection__ = "custom"
     __document_id__ = "foo"
 

--- a/firedantic/tests/tests_async/conftest.py
+++ b/firedantic/tests/tests_async/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import google.auth.credentials
 import pytest
 from google.cloud.firestore_v1 import AsyncClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 
 from firedantic import AsyncBareModel, AsyncModel
 from firedantic.configurations import configure
@@ -18,12 +18,30 @@ class CustomIDModel(AsyncBareModel):
     foo: Optional[str]
     bar: str
 
+    class Config:
+        extra = Extra.forbid
+
+
+class CustomIDModelExtra(AsyncBareModel):
+    __collection__ = "custom"
+    __document_id__ = "foo"
+
+    foo: Optional[str]
+    bar: str
+    baz: str
+
+    class Config:
+        extra = Extra.forbid
+
 
 class CustomIDConflictModel(AsyncModel):
     __collection__ = "custom"
 
     foo: str
     bar: str
+
+    class Config:
+        extra = Extra.forbid
 
 
 class Owner(BaseModel):
@@ -32,6 +50,9 @@ class Owner(BaseModel):
     first_name: str
     last_name: str
 
+    class Config:
+        extra = Extra.forbid
+
 
 class Company(AsyncModel):
     """Dummy company Firedantic model."""
@@ -39,6 +60,9 @@ class Company(AsyncModel):
     __collection__ = "companies"
     company_id: str
     owner: Owner
+
+    class Config:
+        extra = Extra.forbid
 
 
 class Product(AsyncModel):
@@ -49,11 +73,17 @@ class Product(AsyncModel):
     price: float
     stock: int
 
+    class Config:
+        extra = Extra.forbid
+
 
 class TodoList(AsyncModel):
     __collection__ = "todoLists"
     name: str
     items: List[str]
+
+    class Config:
+        extra = Extra.forbid
 
 
 @pytest.fixture

--- a/firedantic/tests/tests_async/test_model.py
+++ b/firedantic/tests/tests_async/test_model.py
@@ -204,7 +204,6 @@ async def test_custom_id_model(configure_db):
     m = models[0]
     assert m.foo is not None
     assert m.bar == "bar"
-    assert m.id is None
 
 
 @pytest.mark.asyncio
@@ -217,4 +216,3 @@ async def test_custom_id_conflict(configure_db):
     m = models[0]
     assert m.foo != "foo"
     assert m.bar == "bar"
-    assert m.id is None

--- a/firedantic/tests/tests_sync/conftest.py
+++ b/firedantic/tests/tests_sync/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import google.auth.credentials
 import pytest
 from google.cloud.firestore_v1 import Client
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 
 from firedantic import BareModel, Model
 from firedantic.configurations import configure
@@ -18,12 +18,30 @@ class CustomIDModel(BareModel):
     foo: Optional[str]
     bar: str
 
+    class Config:
+        extra = Extra.forbid
+
+
+class CustomIDModelExtra(BareModel):
+    __collection__ = "custom"
+    __document_id__ = "foo"
+
+    foo: Optional[str]
+    bar: str
+    baz: str
+
+    class Config:
+        extra = Extra.forbid
+
 
 class CustomIDConflictModel(Model):
     __collection__ = "custom"
 
     foo: str
     bar: str
+
+    class Config:
+        extra = Extra.forbid
 
 
 class Owner(BaseModel):
@@ -32,6 +50,9 @@ class Owner(BaseModel):
     first_name: str
     last_name: str
 
+    class Config:
+        extra = Extra.forbid
+
 
 class Company(Model):
     """Dummy company Firedantic model."""
@@ -39,6 +60,9 @@ class Company(Model):
     __collection__ = "companies"
     company_id: str
     owner: Owner
+
+    class Config:
+        extra = Extra.forbid
 
 
 class Product(Model):
@@ -49,11 +73,17 @@ class Product(Model):
     price: float
     stock: int
 
+    class Config:
+        extra = Extra.forbid
+
 
 class TodoList(Model):
     __collection__ = "todoLists"
     name: str
     items: List[str]
+
+    class Config:
+        extra = Extra.forbid
 
 
 @pytest.fixture

--- a/firedantic/tests/tests_sync/conftest.py
+++ b/firedantic/tests/tests_sync/conftest.py
@@ -7,11 +7,11 @@ import pytest
 from google.cloud.firestore_v1 import Client
 from pydantic import BaseModel
 
-from firedantic import Model
+from firedantic import BareModel, Model
 from firedantic.configurations import configure
 
 
-class CustomIDModel(Model):
+class CustomIDModel(BareModel):
     __collection__ = "custom"
     __document_id__ = "foo"
 

--- a/firedantic/tests/tests_sync/conftest.py
+++ b/firedantic/tests/tests_sync/conftest.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List
+from typing import List, Optional
 from unittest.mock import Mock
 
 import google.auth.credentials
@@ -9,6 +9,21 @@ from pydantic import BaseModel
 
 from firedantic import Model
 from firedantic.configurations import configure
+
+
+class CustomIDModel(Model):
+    __collection__ = "custom"
+    __document_id__ = "foo"
+
+    foo: Optional[str]
+    bar: str
+
+
+class CustomIDConflictModel(Model):
+    __collection__ = "custom"
+
+    foo: str
+    bar: str
 
 
 class Owner(BaseModel):

--- a/firedantic/tests/tests_sync/test_model.py
+++ b/firedantic/tests/tests_sync/test_model.py
@@ -192,7 +192,6 @@ def test_custom_id_model(configure_db):
     m = models[0]
     assert m.foo is not None
     assert m.bar == "bar"
-    assert m.id is None
 
 
 def test_custom_id_conflict(configure_db):
@@ -204,4 +203,3 @@ def test_custom_id_conflict(configure_db):
     m = models[0]
     assert m.foo != "foo"
     assert m.bar == "bar"
-    assert m.id is None

--- a/firedantic/tests/tests_sync/test_model.py
+++ b/firedantic/tests/tests_sync/test_model.py
@@ -4,7 +4,13 @@ from pydantic import Field
 import firedantic.operators as op
 from firedantic import Model
 from firedantic.exceptions import CollectionNotDefined, ModelNotFoundError
-from firedantic.tests.tests_sync.conftest import Company, Product, TodoList
+from firedantic.tests.tests_sync.conftest import (
+    Company,
+    CustomIDConflictModel,
+    CustomIDModel,
+    Product,
+    TodoList,
+)
 
 TEST_PRODUCTS = [
     {"product_id": "a", "stock": 0},
@@ -174,3 +180,28 @@ def test_truncate_collection(configure_db, create_company):
     Company.truncate_collection()
     new_companies = Company.find({})
     assert len(new_companies) == 0
+
+
+def test_custom_id_model(configure_db):
+    c = CustomIDModel(bar="bar")
+    c.save()
+
+    models = CustomIDModel.find({})
+    assert len(models) == 1
+
+    m = models[0]
+    assert m.foo is not None
+    assert m.bar == "bar"
+    assert m.id is None
+
+
+def test_custom_id_conflict(configure_db):
+    CustomIDConflictModel(foo="foo", bar="bar").save()
+
+    models = CustomIDModel.find({})
+    assert len(models) == 1
+
+    m = models[0]
+    assert m.foo != "foo"
+    assert m.bar == "bar"
+    assert m.id is None

--- a/unasync.py
+++ b/unasync.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 
 SUBS = [
+    ("google.cloud.firestore_v1.async_query", "google.cloud.firestore_v1.base_query"),
+    ("AsyncQuery", "BaseQuery"),
     ("AsyncCollectionReference", "CollectionReference"),
     ("AsyncDocumentReference", "DocumentReference"),
     ("AsyncModel", "Model"),

--- a/unasync.py
+++ b/unasync.py
@@ -11,7 +11,7 @@ SUBS = [
     ("AsyncDocumentReference", "DocumentReference"),
     ("AsyncModel", "Model"),
     ("AsyncClient", "Client"),
-    ("TAsyncModel", "TModel"),
+    ("TAsyncBareModel", "TBareModel"),
     ("tests_async", "tests_sync"),
     ("Async([A-Z][A-Za-z0-9_]*)", r"\2"),
     ("async def", "def"),


### PR DESCRIPTION
Increases compatibility with existing datasets, e.g. in some cases it has been beneficial to store the document ID both as the "key" and in the data properties.

This allows both overriding the document ID to use a field other than `id`, and to not crash when there is another `id` or similar in the data.